### PR TITLE
Fixes data corruption when circular buffers fill up.

### DIFF
--- a/src/cmd_read_aux.c
+++ b/src/cmd_read_aux.c
@@ -6,7 +6,7 @@
 #include "tracelib/tracer_state_machine.h"
 #include "xbdm_util.h"
 
-#define BUFFER_SIZE (1024 * 1024)
+#define BUFFER_SIZE (1024 * 1024 + 4)
 
 HRESULT HandleReadAux(const char* command, char* response,
                       uint32_t response_len, CommandContext* ctx) {

--- a/src/cmd_read_pgraph.c
+++ b/src/cmd_read_pgraph.c
@@ -6,7 +6,7 @@
 #include "tracelib/tracer_state_machine.h"
 #include "xbdm_util.h"
 
-#define READ_BUFFER_SIZE (1024 * 64)
+#define READ_BUFFER_SIZE (1024 * 128 + 4)
 
 HRESULT HandleReadPGRAPH(const char* command, char* response,
                          uint32_t response_len, CommandContext* ctx) {

--- a/src/tracelib/pgraph_command_callbacks.c
+++ b/src/tracelib/pgraph_command_callbacks.c
@@ -274,14 +274,6 @@ static void StoreSurface(const PushBufferCommandTraceInfo* info,
 
 void TraceSurfaces(const PushBufferCommandTraceInfo* info, TraceContext* ctx,
                    StoreAuxData store, const AuxConfig* config) {
-  if (config->raw_pgraph_capture_enabled) {
-    StorePGRAPH(info, store);
-  }
-
-  if (config->raw_pfb_capture_enabled) {
-    StorePFB(info, store);
-  }
-
   if (!config->surface_color_capture_enabled &&
       !config->surface_depth_capture_enabled) {
     return;
@@ -614,5 +606,14 @@ void TraceEnd(const PushBufferCommandTraceInfo* info, TraceContext* ctx,
   DbgPrint("END - Packet: %d Draw: %u Surface: %u\n", info->packet_index,
            info->draw_index, info->surface_dump_index);
   ++ctx->draw_index;
+
+  if (config->raw_pgraph_capture_enabled) {
+    StorePGRAPH(info, store);
+  }
+
+  if (config->raw_pfb_capture_enabled) {
+    StorePFB(info, store);
+  }
+
   TraceSurfaces(info, ctx, store, config);
 }


### PR DESCRIPTION
This change fixes an issue where data is duplicated when the PGRAPH or AUX circular buffer do not contain sufficient space to hold the entire object.

The change also increases the size of the buffers to reduce stall frequency.

This also fixes a minor memory leak when using heap buffers for PGRAPH parameters.